### PR TITLE
Move localAar switch outside of dependencySubstitution

### DIFF
--- a/gradle/local-aar.gradle
+++ b/gradle/local-aar.gradle
@@ -7,10 +7,9 @@ ext.customModulePath = { moduleName ->
         return project("$moduleName")
     }
 }
-
-configurations.all {
-    resolutionStrategy.dependencySubstitution {
-        if (useAARForDevBuild) {
+if (useAARForDevBuild) {
+    configurations.all {
+        resolutionStrategy.dependencySubstitution {
             inDevModules.each { moduleName ->
                 substitute module("${localAARPublishConfig.groupId}$moduleName:${localAARPublishConfig.version}") with project(moduleName)
             }


### PR DESCRIPTION
This will prevent the dependencySubstitution API from being called when it is not used.